### PR TITLE
Rename `env.build` to `env.optimize`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [HEAD](https://github.com/LotusTM/Kotsu/compare/v1.15.0...HEAD)
 
+### Added
+- [grunt] Added ability to force "build" version of the build (nice!) by setting `BUILD` environment variable or providing `--build` flag.
+
+   This allows to trigger optimized builds even when running non-build task, like `npm start -- --build`. Yeap, `build` most likely should be replaced with something that makes more sense...
+
 ### Changed
 - [package][grunt][tasks][configs][templates][data][ci] Replaced JSPM with Webpack 4.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 ## [HEAD](https://github.com/LotusTM/Kotsu/compare/v1.15.0...HEAD)
 
 ### Added
-- [grunt] Added ability to force "build" version of the build (nice!) by setting `BUILD` environment variable or providing `--build` flag.
+- [grunt] Added ability to force optimized version of the build by setting `OPTIMIZE` environment variable or providing `--optimize` flag.
 
-   This allows to trigger optimized builds even when running non-build task, like `npm start -- --build`. Yeap, `build` most likely should be replaced with something that makes more sense...
+   It allows to trigger optimized builds not only when running `grunt build`, but while doing any build, like development-one with `npm start -- --optimize`.
 
 ### Changed
 - [package][grunt][tasks][configs][templates][data][ci] Replaced JSPM with Webpack 4.
@@ -29,6 +29,16 @@
 - [package][grunt][configs] Replaced `grunt-browser-sync` with `webpack-dev-server`.
 
    Webpack Dev Server lacks cool syncing mechanism that Browser Sync had, however, let's face it — Browser Sync hasn't been updated for years and seems to be abandoned, while Webpack Dev Servers finally allows to enjoy hot module replacement again.
+
+- [package][grunt][data][scripts][templates] Changed `env.build` to more self-describing `env.optimize`. Finally, those concepts won't be mixed together.
+
+- [package][grunt] `grunt build` no longer triggers optimized build by itself.
+
+   From now on `grunt build` means a specific set of tasks which, on contrary to the development (or default `grunt` command) runs a wider set of tasks, but not specificity optimizes the build.
+
+   Optimized build should be triggered by providing `OPTIMIZE` environment variable or `--optimize` flag. `npm run build` by default does exactly that.
+
+- [package] Changed `npm run build` to clearly define that it should run optimized Grunt build, so command changed from `grunt build` to `grunt build --optimize`.
 
 - [package] Updated dependencies:
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -13,8 +13,7 @@ module.exports = ({ env }) => {
             // Preserve ES6 modules format, needed for tree shaking
             modules: false,
             useBuiltIns: 'usage',
-            corejs: 3,
-            shippedProposals: true
+            corejs: 3
           }
       ]
     ]

--- a/docs/Data.md
+++ b/docs/Data.md
@@ -170,7 +170,7 @@ Some useful for project environment variables.
 |---------------------------|-----------|-------------------------|------------------------------------------------------------------|
 | `[ENV.production]`        | `Boolean` | `env.production`        | Denotes production build.                                        |
 | `[ENV.staging]`           | `Boolean` | `env.staging`           | Denotes staging build.                                           |
-| `[ENV.build]`             | `Boolean` | `env.build`             | Denotes fully optimized build. Usually same as production build. |
+| `[ENV.optimize]`          | `Boolean` | `env.optimize`          | Denotes fully optimized build.                                   |
 | `[ENV.buildSHA1]`         | `String`  | `env.buildSHA1`         | Commit SHA1, which caused Circle CI build.                       |
 | `[ENV.buildNumber]`       | `String`  | `env.buildNumber`       | Current Circle CI build.                                         |
 | `[ENV.hotModuleRloading]` | `Boolean` | `env.hotModuleRloading` | Is Hot Module Reloading used right now.                          |

--- a/docs/Environment-variables.md
+++ b/docs/Environment-variables.md
@@ -19,8 +19,9 @@ TINYPNG_API_KEY | Yes[*](#required) | Yes[*](#required) | String | used by `grun
 GITHUB_API_KEY | Yes[*](#required) | Yes[*](#required) | String | used by `jspm` to access GitHub API. It's an unencrypted Base64 encoding of the GitHub username and password or access token separated by a `:` (e.g. `username:token`). Get your token [here](https://github.com/settings/tokens)
 SERVER_IP | No | Yes[*](#required) | String | an IP address or domain of your server where CI will automatically deploy
 SITENAME | No | Yes[*](#required) | String | your site name without protocol specification (e.g. `exapmple.com`)
-PRODUCTION | No | Yes | Boolean | `true` by default if using `grunt build`, `false` for `grunt`, useful if you want to override this behavior
+PRODUCTION | No | Yes | Boolean | `false` by default
 STAGING | No | Yes | Boolean | `false` by default
+BUILD | No | Yes | Boolean | `false` by default except for `npm run build` (and invoked by it `grunt build`) command. Usually you don't want to touch it.
 
 # Required
 Variables marked as with asterisk (*) are required for related development environment

--- a/docs/Environment-variables.md
+++ b/docs/Environment-variables.md
@@ -21,7 +21,7 @@ SERVER_IP | No | Yes[*](#required) | String | an IP address or domain of your se
 SITENAME | No | Yes[*](#required) | String | your site name without protocol specification (e.g. `exapmple.com`)
 PRODUCTION | No | Yes | Boolean | `false` by default
 STAGING | No | Yes | Boolean | `false` by default
-BUILD | No | Yes | Boolean | `false` by default except for `npm run build` (and invoked by it `grunt build`) command. Usually you don't want to touch it.
+OPTIMIZE | No | Yes | Boolean | `false` by default except for `npm run build`. Usually you don't want to touch it.
 
 # Required
 Variables marked as with asterisk (*) are required for related development environment

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -26,7 +26,7 @@ module.exports = function (grunt) {
       sitename: process.env.SITENAME,
       production: (process.env.PRODUCTION === 'true') || grunt.option('production'),
       staging: (process.env.STAGING === 'true') || grunt.option('staging'),
-      build: grunt.cli.tasks.includes('build'),
+      build: (process.env.BUILD === 'true') || grunt.cli.tasks.includes('build') || grunt.option('build'),
       buildSHA1: process.env.CIRCLE_SHA1,
       buildNumber: process.env.CIRCLE_BUILD_NUM,
       hotModuleRloading: grunt.option('hmr'),

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -26,7 +26,7 @@ module.exports = function (grunt) {
       sitename: process.env.SITENAME,
       production: (process.env.PRODUCTION === 'true') || grunt.option('production'),
       staging: (process.env.STAGING === 'true') || grunt.option('staging'),
-      build: (process.env.BUILD === 'true') || grunt.cli.tasks.includes('build') || grunt.option('build'),
+      optimize: (process.env.OPTIMIZE === 'true') || grunt.option('optimize'),
       buildSHA1: process.env.CIRCLE_SHA1,
       buildNumber: process.env.CIRCLE_BUILD_NUM,
       hotModuleRloading: grunt.option('hmr'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -3642,9 +3642,9 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
     "core-js": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.4.tgz",
-      "integrity": "sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ=="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.0.tgz",
+      "integrity": "sha512-gybgLzmr7SQRSF6UzGYXducx4eE10ONQlyEnQoqiGPbmbn7zLkb73tPfc4YbZN0lvcTQwoLNPjq4RuCaCumGyQ=="
     },
     "core-js-compat": {
       "version": "3.1.4",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   ],
   "dependencies": {
     "autoprefixer": "9.6.1",
-    "core-js": "3.1.4",
+    "core-js": "3.2.0",
     "gettext-parser": "4.0.1",
     "gmsmith": "1.2.0",
     "grunt": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "pretest": "grunt writeJSON:scripts",
     "test": "npm run lint && jest",
     "test:watch": "jest --watch",
-    "build": "grunt build",
+    "build": "grunt build --optimize",
     "preversion": "npm test && npm run build",
     "version": "node modules/changelog-version",
     "postbuild": "node modules/clean-workdir"

--- a/source/data/index.js
+++ b/source/data/index.js
@@ -63,7 +63,7 @@ module.exports = ({ config }) => {
     ENV: {
       production: env.production,
       staging: env.staging,
-      build: env.build,
+      optimize: env.optimize,
       buildSHA1: env.buildSHA1,
       buildNumber: env.buildNumber,
       hotModuleRloading: env.hotModuleRloading

--- a/source/data/index.test.js
+++ b/source/data/index.test.js
@@ -120,7 +120,7 @@ const Data = t.struct({
   ENV: t.struct({
     production: t.maybe(t.Boolean),
     staging: t.maybe(t.Boolean),
-    build: t.maybe(t.Boolean),
+    optimize: t.maybe(t.Boolean),
     buildSHA1: t.maybe(t.String),
     buildNumber: t.maybe(t.String),
     hotModuleRloading: t.maybe(t.Boolean)

--- a/source/data/scripts.js
+++ b/source/data/scripts.js
@@ -23,7 +23,7 @@ module.exports = (grunt) => {
       baseLocale
     },
     ENV: {
-      build,
+      optimize,
       buildSHA1,
       buildNumber,
       staging,
@@ -44,7 +44,7 @@ module.exports = (grunt) => {
       baseLocale
     },
     ENV: {
-      build,
+      optimize,
       buildSHA1,
       buildNumber,
       staging,

--- a/source/scripts/serviceWorker/register.js
+++ b/source/scripts/serviceWorker/register.js
@@ -1,7 +1,7 @@
 import data from '@data'
 
 const { PATH, ENV } = data
-const swUrl = `/${ENV.build ? PATH.file.serviceWorker.minified : PATH.file.serviceWorker.compiled}`
+const swUrl = `/${ENV.optimize ? PATH.file.serviceWorker.minified : PATH.file.serviceWorker.compiled}`
 
 export default () => {
   if (!navigator.serviceWorker) return console.log('Service worker isn\'t supported')

--- a/source/templates/_components/IE.nj
+++ b/source/templates/_components/IE.nj
@@ -10,7 +10,7 @@
 {% macro IE(version = 'lte IE 9') %}
 <!--[if {{ version }}]>
 
-  <link rel='stylesheet' href='{{ urljoin('/', PATH.styles, 'ie.min.css' if ENV.build else 'ie.prefixed.css') }}'>
+  <link rel='stylesheet' href='{{ urljoin('/', PATH.styles, 'ie.min.css' if ENV.optimize else 'ie.prefixed.css') }}'>
 
   <script>
     var e = ('abbr,article,aside,audio,canvas,datalist,details,' +

--- a/source/templates/_layouts/base.nj
+++ b/source/templates/_layouts/base.nj
@@ -30,7 +30,7 @@
 
   <!-- CSS -->
   {% block css %}
-  <link rel='stylesheet' href='{{ urljoin('/', PATH.styles, 'style.min.css' if ENV.build else 'style.prefixed.css') }}'>
+  <link rel='stylesheet' href='{{ urljoin('/', PATH.styles, 'style.min.css' if ENV.optimize else 'style.prefixed.css') }}'>
   {% endblock %}
 
   <!-- Manifest -->
@@ -115,9 +115,9 @@
   <!-- ======= -->
 
   {% block js %}
-  <script src='{{ urljoin('\/', PATH.file.scriptRuntime.minified if ENV.build else PATH.file.scriptRuntime.compiled) }}'></script>
-  <script src='{{ urljoin('\/', PATH.file.script.minified if ENV.build else PATH.file.script.compiled) }}'></script>
-  <script src='{{ urljoin('\/', PATH.file.scriptExternals.minified if ENV.build else PATH.file.scriptExternals.compiled) }}'></script>
+  <script src='{{ urljoin('\/', PATH.file.scriptRuntime.minified if ENV.optimize else PATH.file.scriptRuntime.compiled) }}'></script>
+  <script src='{{ urljoin('\/', PATH.file.script.minified if ENV.optimize else PATH.file.script.compiled) }}'></script>
+  <script src='{{ urljoin('\/', PATH.file.scriptExternals.minified if ENV.optimize else PATH.file.scriptExternals.compiled) }}'></script>
   {% endblock %}
 
   {{ GoogleGlobalTag(UAId = SITE.googleAnalyticsId) if SITE.googleAnalyticsId }}

--- a/tasks/styles.js
+++ b/tasks/styles.js
@@ -43,10 +43,10 @@ module.exports = function () {
         cwd: '<%= path.build.styles %>',
         src: '{,**/}*.compiled.css',
         dest: '<%= path.build.styles %>',
-        // In build we have to name this file as final stylesheet would be named,
+        // In optimized build we have to name this file as final stylesheet would be named,
         // because due to build mode this is what will be stated in HTML pages
         // and for what will look `uncss` task
-        ext: this.config('env.build') ? '.min.css' : '.prefixed.css'
+        ext: this.config('env.optimize') ? '.min.css' : '.prefixed.css'
       }]
     }
   })

--- a/webpack.config.common.js
+++ b/webpack.config.common.js
@@ -2,12 +2,12 @@ const { resolve } = require('path')
 const webpack = require('webpack')
 
 module.exports = ({ env = {}, path = {}, file = {} }) => {
-  const isBuild = env.build // --env.production
+  const isOptimized = env.optimize // --env.production
 
   return {
     target: 'web',
-    mode: isBuild ? 'production' : 'development',
-    devtool: isBuild ? 'source-map' : 'eval-source-map',
+    mode: isOptimized ? 'production' : 'development',
+    devtool: isOptimized ? 'source-map' : 'eval-source-map',
     devServer: {
       contentBase: `./${path.build.root}`,
       overlay: true,
@@ -41,7 +41,7 @@ module.exports = ({ env = {}, path = {}, file = {} }) => {
       }
     },
     plugins: [
-      isBuild
+      isOptimized
         ? new webpack.HashedModuleIdsPlugin()
         : new webpack.NamedModulesPlugin()
     ]

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,7 @@ const webpack = require('webpack')
 
 module.exports = ({ env = {}, path = {}, file = {} }) => {
   const commonConfig = common({ env, path, file })
-  const isBuild = env.build // --env.production
+  const isOptimized = env.optimize // --env.production
 
   return Object.assign(
     {},
@@ -14,7 +14,7 @@ module.exports = ({ env = {}, path = {}, file = {} }) => {
       entry: `./${file.source.scripts.main}`,
       output: {
         path: resolve(__dirname, path.build.scripts),
-        filename: isBuild ? `[name].${file.build.scriptMinifiedExt}.js` : '[name].js',
+        filename: isOptimized ? `[name].${file.build.scriptMinifiedExt}.js` : '[name].js',
         publicPath: path.build.scripts.replace(path.build.root, '')
       },
       optimization: {

--- a/webpack.config.sw.js
+++ b/webpack.config.sw.js
@@ -2,7 +2,7 @@ const { resolve, basename } = require('path')
 const common = require('./webpack.config.common')
 
 module.exports = ({ env = {}, path = {}, file = {} }) => {
-  const isBuild = env.build // --env.production
+  const isOptimized = env.optimize // --env.production
 
   return Object.assign(
     {},
@@ -12,7 +12,7 @@ module.exports = ({ env = {}, path = {}, file = {} }) => {
       entry: `./${file.source.scripts.serviceWorker}`,
       output: {
         path: resolve(__dirname, path.build.root),
-        filename: isBuild
+        filename: isOptimized
           ? basename(file.build.serviceWorker.minified)
           : basename(file.build.serviceWorker.compiled)
       }


### PR DESCRIPTION
An attempt to clarify the terms.

Currently, under the term `build` we mean "optimized build". It worked and seemed right, because when we run `grunt build` we on purpose invoke a specific, wider set of tasks, to get better-optimized build. And thus, we used `env.build` as a reference, which denoted that system right now in the `optimization` state (`build`-one) and should treat assets according to it.

 `env.build`,  most specifically, affects the size of the produced files _and_ filenames (include or not include `.min` part). And thus, it affects file paths in templates and scripts.

However, as Kotsu evolved, it started to make less sense since some parts of that system are quite independent. For instance, Webpack optimizations can be triggered by its own, not within `grunt build` task. And that sometimes makes perfect sense.

Besides, `env.build`, which expressed an optimized state of the system, became a quite confusing term. It makes sense when you read the explanation above, but doesn't in isolation. For instance, while looking into Webpack config you see `env.build` variable. What exactly it means? Like, really nothing.

This also leads to a terminology confusion. We mean that build is "optimized build". However, `npm start` in fact produces build too, but that's not the build we meant originally. And you can even do `npm start -- --optimized` which makes sense during testing. But that produces another build, but not the build we meant!

So, it feels logical to provide more self-describing variable `env.optimized` and deattach `build` command from the original meaning of the "optimized build".

There are few concerns, though:

1. `grunt build --optimize` or `grunt build --optimizED`?
2. We still have that command `grunt build` which triggers part of the optimizations. That means that you can run `npm start -- --optimize` to get partially optimized development build with watch or `npm run build` (`grunt build --optimize) to get fully optimized build without watch.

   I'm trying to get is it correct, since it feels like not that obvious.

   Maybe the problem is in the intention we try to convey here. For instance, what difference we really want between `npm start` and `npm run build` is watching. So, when I run `npm start` I expect it to be build and watch, while `npm run build` should not. In that case, we'd want the additional command to run optimized build. Or maybe the list of commands should be completely revisited. Still thinking about it.